### PR TITLE
Options hash and namedtuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ openai = OpenAI::Client.new(access_token: ENV.fetch("OPENAI_API_KEY"))
 
 # List and show models
 openai.models.list
-openai.models.retreive("davinci")
+openai.models.retrieve("davinci")
 
 # Creates a completion for the chat message
 openai.chat("gpt-3.5-turbo", [
@@ -55,11 +55,11 @@ Some endpoints are still under active development. I could use help if you want 
 
 ## Development
 
-The specs use webmock. You can comment them out to run a real request using your own Open AI API key. 
-I tried to make the requests use as few tokens as possible. If you plan on updating or adding an endpoint, 
-it's usually easiest if you copy the response from the Open AI API docs and stick it in the fixtures folder. 
-From there, build out a response struct inside of responses.cr and the rest should be fairly straight forward 
-with the client endpoints. If a resource has multiple endpoints like models or audio, it might be a good idea 
+The specs use webmock. You can comment them out to run a real request using your own Open AI API key.
+I tried to make the requests use as few tokens as possible. If you plan on updating or adding an endpoint,
+it's usually easiest if you copy the response from the Open AI API docs and stick it in the fixtures folder.
+From there, build out a response struct inside of responses.cr and the rest should be fairly straight forward
+with the client endpoints. If a resource has multiple endpoints like models or audio, it might be a good idea
 to stick them in their own file for better organization.
 
 At some point I want to get deeper into the error messages and handle these better as well.

--- a/src/client.cr
+++ b/src/client.cr
@@ -10,7 +10,7 @@ module OpenAI
       OpenAI.configuration.organization_id = organization_id if organization_id
     end
 
-    def chat(model : String, messages : Array(NamedTuple(role: String, content: String)), options : Hash | Nil = nil)
+    def chat(model : String, messages : Array(NamedTuple(role: String, content: String)), options : Hash | NamedTuple | Nil = nil)
       parameters = {
         "model"    => model,
         "messages" => messages,
@@ -19,22 +19,22 @@ module OpenAI
       ChatResponse.from_json(post(path: "/chat/completions", parameters: parameters))
     end
 
-    def completions(model : String, prompt : String, options : Hash | Nil = nil)
+    def completions(model : String, prompt : String, options : Hash | NamedTuple | Nil = nil)
       parameters = {
         "model"  => model,
         "prompt" => prompt,
       }
-      parameters = parameters.merge(options) if options
+      parameters = parameters.merge(options.to_h) if options
       CompletionsResponse.from_json(post(path: "/completions", parameters: parameters))
     end
 
-    def edits(model : String, input : String, instruction : String, options : Hash | Nil = nil)
+    def edits(model : String, input : String, instruction : String, options : Hash | NamedTuple | Nil = nil)
       parameters = {
         "model"       => model,
         "input"       => input,
         "instruction" => instruction,
       }
-      parameters = parameters.merge(options) if options
+      parameters = parameters.merge(options.to_h) if options
       EditsResponse.from_json(post(path: "/edits", parameters: parameters))
     end
 


### PR DESCRIPTION
@lancecarlson, when I tried to compile the usage sample in the `README` I ran into two minor issues:

1. Typo when calling `retrieve` method
2. Compile error when passing `NamedTuple` options.

This PR fixes both. 

FYI, I ran `crystal test` with a dummy env var and all tests passed, using `crystal` 1.7.3.