### PR TITLE
Fixes Error: missing hash key "functions"

### DIFF
--- a/spec/chat_spec.cr
+++ b/spec/chat_spec.cr
@@ -65,5 +65,26 @@ describe OpenAI do
 
       pp CatNameResponse.from_json(output)
     end
+
+    it "should chat without functions" do
+      client = OpenAI::Client.new
+
+      response = client.chat("gpt-3.5-turbo", [{role: "user", content: "Give me a list of names for my cat."}])
+      
+      pp response
+    end
+
+    it "should chat with the streaming API without functions being provided" do
+      client = OpenAI::Client.new
+
+      output = ""
+      client.chat("gpt-3.5-turbo", [
+        {role: "user", content: "Give me 30 cat names as a comma separated list"},
+      ], {"stream" => true}) do |chunk| 
+        output += chunk.to_json.to_s
+      end
+
+      pp output
+    end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -3,7 +3,7 @@ require "webmock"
 require "dotenv"
 require "../src/openai"
 
-Dotenv.load
+Dotenv.load if ENV["OPENAI_ACCESS_TOKEN"].nil?
 
 WebMock.allow_net_connect = true
 

--- a/src/client.cr
+++ b/src/client.cr
@@ -15,7 +15,7 @@ module OpenAI
       parameters = prepare_chat_parameters(model, messages, options)
       path = "/chat/completions"
 
-      if parameters["functions"].empty?
+      if parameters["functions"].nil? || parameters["functions"].empty?
         ChatResponse.from_json(post(path: path, parameters: parameters))
       else
         ChatFunctionResponse.from_json(post(path: path, parameters: parameters))

--- a/src/client.cr
+++ b/src/client.cr
@@ -15,7 +15,7 @@ module OpenAI
       parameters = prepare_chat_parameters(model, messages, options)
       path = "/chat/completions"
 
-      if parameters["functions"].nil? || parameters["functions"].empty?
+      if parameters["functions"]?.nil? || parameters["functions"].empty?
         ChatResponse.from_json(post(path: path, parameters: parameters))
       else
         ChatFunctionResponse.from_json(post(path: path, parameters: parameters))


### PR DESCRIPTION
It appears that when adding support for functions, the function-less version of `chat` was broken.

This fixes that and adds two tests to ensure that both streaming and non-streaming `chat` will continue to work as changes are made.

Also, I don't use `Dotenv` but I do set environment variables, so I added a little logic to skip loading from `Dotenv` if the required ENV variable can be found.

I did _not_ test for if someone passes in an empty array of functions. That's probably a good idea to do, but I needed this to work for a project and I don't use functions :)