### PR TITLE
move base url to OpenAI.configuration

### DIFF
--- a/src/client.cr
+++ b/src/client.cr
@@ -3,11 +3,10 @@ module OpenAI
     class ClientError < Exception
     end
 
-    URI_BASE = "https://api.openai.com/"
-
-    def initialize(access_token : String | Nil = nil, organization_id : String | Nil = nil, logger : Log = Log.for("openai.client"))
+    def initialize(access_token : String | Nil = nil, organization_id : String | Nil = nil, logger : Log = Log.for("openai.client"), base_url : String | Nil = nil)
       OpenAI.configuration.access_token = access_token if access_token
       OpenAI.configuration.organization_id = organization_id if organization_id
+      OpenAI.configuration.base_url = base_url if base_url
       @logger = logger
     end
 
@@ -152,7 +151,7 @@ module OpenAI
     end
 
     private def client
-      HTTP::Client.new(URI.parse(URI_BASE))
+      HTTP::Client.new(URI.parse(OpenAI.configuration.base_url))
     end
 
     private def handle_response(response) : String

--- a/src/openai.cr
+++ b/src/openai.cr
@@ -16,10 +16,12 @@ module OpenAI
     setter :access_token
     property :api_version
     property :organization_id
+    property :base_url
 
+    DEFAULT_BASE_URL = "https://api.openai.com"
     DEFAULT_API_VERSION = "v1"
 
-    def initialize(@access_token : String | Nil = nil, @api_version = DEFAULT_API_VERSION, @organization_id : String | Nil = nil)
+    def initialize(@access_token : String | Nil = nil, @api_version = DEFAULT_API_VERSION, @organization_id : String | Nil = nil, @base_url = DEFAULT_BASE_URL)
     end
 
     def access_token


### PR DESCRIPTION
This PR adds the ability for the base url to be changed, this makes openai.cr compatible with openai API replacements. It takes care of #4 

```crystal
openai = OpenAI::Client.new(access_token: ENV.fetch("OPENAI_API_KEY"), base_url: "http://localhost:8080")
```